### PR TITLE
Remove confusing step from build instructions provided by configure script

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -94,6 +94,5 @@ fi
 
 echo
 echo "Finish configuration. To build, type:"
-echo "> cd \$LARCV_BUILDDIR"
 echo "> make "
 echo


### PR DESCRIPTION
You should not actually change directories before typing `make`, you should just type `make`