### PR TITLE
Added Batch Filler for BBox2D objects

### DIFF
--- a/larcv/app/ThreadIO/BatchFillerBBox2D.cxx
+++ b/larcv/app/ThreadIO/BatchFillerBBox2D.cxx
@@ -18,6 +18,7 @@ namespace larcv {
   {
     _bbox2d_producer = cfg.get<std::string>("BBox2DProducer");
     _projid = (ProjectionID_t)cfg.get<int>("ProjectionID");
+    _maxboxes = cfg.get<int>("MaxNumBoxes");
   }
 
   void BatchFillerBBox2D::initialize()
@@ -25,11 +26,15 @@ namespace larcv {
 
   void BatchFillerBBox2D::_batch_begin_()
   {
+    
+    
     if (!batch_data().dim().empty() && (int)(batch_size()) != batch_data().dim().front()) {
       auto dim = batch_data().dim();
       dim[0] = batch_size();
       this->set_dim(dim);
     }
+
+    _entry_data.resize(batch_size()*4*_maxboxes,0);    
   }
 
   void BatchFillerBBox2D::_batch_end_()
@@ -41,13 +46,17 @@ namespace larcv {
 
   bool BatchFillerBBox2D::process(IOManager & mgr)
   {
+
+    LARCV_DEBUG() << "start" << std::endl;
+    
     auto const& event_bbox2d = mgr.get_data<larcv::EventBBox2D>(_bbox2d_producer);
 
     // if slow, one thing to try is to allocate this only once
     // by keeping as member data
     std::vector< std::array<float,4> > tempstore;
     tempstore.reserve( event_bbox2d.size() );
-    
+
+
     for ( auto const& bbox2d : event_bbox2d ) {
       if ( bbox2d.id()!=_projid )
 	continue;
@@ -60,20 +69,32 @@ namespace larcv {
 
       tempstore.push_back( xybh );
     }
+      
+    int nboxes = tempstore.size();
+    LARCV_DEBUG() << "Number of boxes in event: " << nboxes << std::endl;    
+    if ( nboxes>_maxboxes )
+      nboxes = _maxboxes;
     
-    
-    std::vector<int> dim(2);
-    dim[0] = batch_size();
-    dim[1] = tempstore.size();
-    this->set_dim(dim);
-    _entry_data.resize(4*dim[1],0);
-    for ( size_t ibox=0; ibox<tempstore.size(); ibox++ ) {
+    if (batch_data().dim().empty()) {
+      LARCV_DEBUG() << "Setting batch size" << std::endl;
+      std::vector<int> dim(4);
+      dim[0] = batch_size();
+      dim[1] = _maxboxes;
+      dim[2] = 1;
+      dim[3] = 4;
+      this->set_dim(dim);
+    }
+    _entry_data.resize(4*_maxboxes,0);
+    for (auto& v : _entry_data) v = 0.;
+	  
+    for ( int ibox=0; ibox<nboxes; ibox++ ) {
       auto& bbox2d = tempstore[ibox];
       for (int i=0; i<4; i++) 
 	_entry_data[4*ibox+i] = bbox2d[i];
     }
-    set_entry_data(_entry_data);
-    
+    this->set_entry_data(_entry_data);
+
+    LARCV_DEBUG() << "end" << std::endl;    
     return true;
   }
 

--- a/larcv/app/ThreadIO/BatchFillerBBox2D.cxx
+++ b/larcv/app/ThreadIO/BatchFillerBBox2D.cxx
@@ -1,0 +1,81 @@
+#ifndef __BatchFillerBBox2D_CXX__
+#define __BatchFillerBBox2D_CXX__
+
+#include "BatchFillerBBox2D.h"
+#include "larcv/core/DataFormat/EventImage2D.h"
+#include "larcv/core/DataFormat/EventBBox.h"
+#include <random>
+
+namespace larcv {
+
+  static BatchFillerBBox2DProcessFactory __global_BatchFillerBBox2DProcessFactory__;
+
+  BatchFillerBBox2D::BatchFillerBBox2D(const std::string name)
+    : BatchFillerTemplate<float>(name)
+  {}
+
+  void BatchFillerBBox2D::configure(const PSet& cfg)
+  {
+    _bbox2d_producer = cfg.get<std::string>("BBox2DProducer");
+    _projid = (ProjectionID_t)cfg.get<int>("ProjectionID");
+  }
+
+  void BatchFillerBBox2D::initialize()
+  {}
+
+  void BatchFillerBBox2D::_batch_begin_()
+  {
+    if (!batch_data().dim().empty() && (int)(batch_size()) != batch_data().dim().front()) {
+      auto dim = batch_data().dim();
+      dim[0] = batch_size();
+      this->set_dim(dim);
+    }
+  }
+
+  void BatchFillerBBox2D::_batch_end_()
+  {
+  }
+
+  void BatchFillerBBox2D::finalize()
+  {}
+
+  bool BatchFillerBBox2D::process(IOManager & mgr)
+  {
+    auto const& event_bbox2d = mgr.get_data<larcv::EventBBox2D>(_bbox2d_producer);
+
+    // if slow, one thing to try is to allocate this only once
+    // by keeping as member data
+    std::vector< std::array<float,4> > tempstore;
+    tempstore.reserve( event_bbox2d.size() );
+    
+    for ( auto const& bbox2d : event_bbox2d ) {
+      if ( bbox2d.id()!=_projid )
+	continue;
+
+      std::array<float,4> xybh;
+      xybh[0] = bbox2d.center_x();
+      xybh[1] = bbox2d.center_y();
+      xybh[2] = bbox2d.width();
+      xybh[3] = bbox2d.height();
+
+      tempstore.push_back( xybh );
+    }
+    
+    
+    std::vector<int> dim(2);
+    dim[0] = batch_size();
+    dim[1] = tempstore.size();
+    this->set_dim(dim);
+    _entry_data.resize(4*dim[1],0);
+    for ( size_t ibox=0; ibox<tempstore.size(); ibox++ ) {
+      auto& bbox2d = tempstore[ibox];
+      for (int i=0; i<4; i++) 
+	_entry_data[4*ibox+i] = bbox2d[i];
+    }
+    set_entry_data(_entry_data);
+    
+    return true;
+  }
+
+}
+#endif

--- a/larcv/app/ThreadIO/BatchFillerBBox2D.h
+++ b/larcv/app/ThreadIO/BatchFillerBBox2D.h
@@ -52,6 +52,10 @@ namespace larcv {
     // bounding boxes from different views
     ProjectionID_t _projid;
 
+    // we're stuck with a fixed batch size. So we need to cap num of boxes
+    // if slot unused, vaues are 0,0,0,0
+    int _maxboxes;
+
     // the name of the ROOT tree storing bbox2d instances
     std::string _bbox2d_producer;
 

--- a/larcv/app/ThreadIO/BatchFillerBBox2D.h
+++ b/larcv/app/ThreadIO/BatchFillerBBox2D.h
@@ -59,6 +59,13 @@ namespace larcv {
     // the name of the ROOT tree storing bbox2d instances
     std::string _bbox2d_producer;
 
+    // we read the x,y values from BBox2D. However, if this
+    // is in the (x,y) coordinates of the Image2D and not in the pixel coordinates
+    // we need to convert. Set the configuration parameter, ConvertXTtoPixel, to true to do this.
+    // You also need to provide the image2d producer from which we will get the meta
+    bool _convert_xy_to_pix;
+    std::string _imageproducer;
+
     // entry_data is where we store values before passing it into the
     // data members of the parent BatchFillerTemplate class
     // we have to provide unrolled values.

--- a/larcv/app/ThreadIO/BatchFillerBBox2D.h
+++ b/larcv/app/ThreadIO/BatchFillerBBox2D.h
@@ -1,0 +1,84 @@
+/**
+ * \file BatchFillerBBox2D.h
+ *
+ * \ingroup ThreadIO
+ * 
+ * \brief Class def header for a class BatchFillerBBox2D
+ *
+ * @author twongjirad
+ */
+
+/** \addtogroup ThreadIO
+
+    @{*/
+#ifndef __BATCHFILLERBBOX2D_H__
+#define __BATCHFILLERBBOX2D_H__
+
+#include "larcv/core/Processor/ProcessFactory.h"
+#include "BatchFillerTemplate.h"
+
+namespace larcv {
+
+  /**
+     \class BatchFillerBBox2D
+     From bbox2d trees, fills bbounding boxes.
+  */
+  class BatchFillerBBox2D : public BatchFillerTemplate<float> {
+
+  public:
+    
+    /// Default constructor
+    BatchFillerBBox2D(const std::string name="BatchFillerBBox2D");
+    
+    /// Default destructor
+    ~BatchFillerBBox2D(){}
+
+    void configure(const PSet&);
+
+    void initialize();
+
+    bool process(IOManager& mgr);
+
+    void _batch_begin_();
+
+    void _batch_end_();
+
+    void finalize();
+
+  private:
+
+    // we only load boxes from a certain projection (view).
+    // create multiple instances of batchfillerbox2d to load
+    // bounding boxes from different views
+    ProjectionID_t _projid;
+
+    // the name of the ROOT tree storing bbox2d instances
+    std::string _bbox2d_producer;
+
+    // entry_data is where we store values before passing it into the
+    // data members of the parent BatchFillerTemplate class
+    // we have to provide unrolled values.
+    // so values ordered like: center-x,center-y,width,height,center-x,...    
+    std::vector< float > _entry_data; 
+
+  };
+
+  /**
+     \class larcv::BatchFillerBBox2DFactory
+     \brief A concrete factory class for larcv::BatchFillerBBox2D
+  */
+  class BatchFillerBBox2DProcessFactory : public ProcessFactoryBase {
+  public:
+    /// ctor
+    BatchFillerBBox2DProcessFactory() { ProcessFactory::get().add_factory("BatchFillerBBox2D",this); }
+    /// dtor
+    ~BatchFillerBBox2DProcessFactory() {}
+    /// creation method
+    ProcessBase* create(const std::string instance_name) { return new BatchFillerBBox2D(instance_name); }
+  };
+
+}
+
+#endif
+/** @} */ // end of doxygen group 
+

--- a/larcv/app/ThreadIO/LinkDef.h
+++ b/larcv/app/ThreadIO/LinkDef.h
@@ -34,6 +34,7 @@
 #pragma link C++ class larcv::BatchFillerMultiLabel+;
 #pragma link C++ class larcv::BatchFillerImage2D+;
 #pragma link C++ class larcv::BatchFillerTensor3D+;
+#pragma link C++ class larcv::BatchFillerBBox2D+;
 //#pragma link C++ class larcv::ThreadFillerFactory+;
 #pragma link C++ class larcv::RandomCropper+;
 //#pragma link C++ class larcv::ExampleCircularBuffer+;


### PR DESCRIPTION
Batch Filler for BBox2D objects.

I do not have push permission on larcv2 repo, but thought I'd share his if useful. If not, no pressure to merge. 

One issue is that batch tensor size is not dynamic.  So had to implement MaxNumBoxes parameter which has to be set high enough to not contain clip number of BBox2D objects per image.

Also, made the choice to only return BBox2D per View (per projectionid). User has to create multiple filler instances to get bboxes for each view.

Tested using larcvdataset module. Test script in develop branch of repo.