### PR TITLE
Added docker dependencies that allow for running the notebook examples

### DIFF
--- a/.Dockerfile
+++ b/.Dockerfile
@@ -25,7 +25,12 @@ ENV LARCV_PYTHON_CONFIG=python3.6-config
 ENV PATH=${LARCV_BASEDIR}/bin:${LARCV_BINDIR}:${PATH}
 ENV LD_LIBRARY_PATH=${LARCV_LIBDIR}:${LD_LIBRARY_PATH}:
 ENV PYTHONPATH=${LARCV_BASEDIR}/python:${PYTHONPATH}
-
+RUN apt-get update && apt-get install -y \
+	python3-pip
+RUN python3 -m pip install jupyter
+RUN python3 -m pip install matplotlib
+RUN python3 -m pip install pandas
+RUN python3 -m pip install scipy
 # larcv
 RUN mkdir -p /app && \
     cd /app && \


### PR DESCRIPTION
Hi,

I found that the easiest way of running your notebooks (https://github.com/DeepLearnPhysics/Blog) is to run dockerfile, with slight modification.
You can see the modifications in pull request.

Cheers,
MM
