### PR TITLE
Feature/pca

### DIFF
--- a/larcv/app/ImageMod/CombineTensor3D.cxx
+++ b/larcv/app/ImageMod/CombineTensor3D.cxx
@@ -50,7 +50,7 @@ namespace larcv {
       case kMaxPool:
       case kMinPool:
         for(auto const& vox : ev_tensor3d.as_vector()) {
-          auto const& exist_vox = (_fuzzy_distance <= 0.) ? vs.find(vox.id()) : vs.close(vox.id(), _fuzzy_distance, meta);
+          auto const& exist_vox = (_fuzzy_distance <= 0.) ? vs.find(vox.id()) : vs.close(vox.id(), _fuzzy_distance);
           if(exist_vox.id() == kINVALID_VOXELID) {
             vs.add(vox);
             continue;

--- a/larcv/core/DataFormat/Voxel3D.cxx
+++ b/larcv/core/DataFormat/Voxel3D.cxx
@@ -3,7 +3,7 @@
 
 #include "Voxel3D.h"
 #include <iostream>
-#include "utils.h"
+#include <algorithm>
 
 namespace larcv {
 	SparseTensor3D::SparseTensor3D(VoxelSet&& vs, Voxel3DMeta meta)
@@ -104,6 +104,30 @@ namespace larcv {
 
 		return Point3D(output[0], output[1], output[2]);
 	}
+
+  PCA_3D SparseTensor3D::fit_pca(bool store_spread, bool use_true_coord)
+  {
+    PCA_3D::Points_t points(this->size());
+
+    // fill (x,y,z) from voxel id or xyz
+		for (size_t i = 0; i < points.size; ++i) {
+			Voxel v = this->as_vector()[i];
+      if (use_true_coord) {
+        Point3D p = this->meta().position(v.id());
+        points.xyz[i][0] = p.x;
+        points.xyz[i][1] = p.y;
+        points.xyz[i][2] = p.z;
+      }
+      else {
+        size_t ix, iy, iz;
+        this->meta().id_to_xyz_index(v.id(), ix, iy, iz);
+        points.xyz[i][0] = ix;
+        points.xyz[i][1] = iy;
+        points.xyz[i][2] = iz;
+      }
+		}
+    return PCA_3D(points, store_spread);
+  }
 
 	void ClusterVoxel3D::meta(const larcv::Voxel3DMeta& meta)
 	{

--- a/larcv/core/DataFormat/Voxel3D.cxx
+++ b/larcv/core/DataFormat/Voxel3D.cxx
@@ -96,8 +96,12 @@ namespace larcv {
 		}
 
 		double output[3];
-		std::cout << "starting" << std::endl;
 		compute_pca(coords, npts, output);
+
+    // coords: free me please!
+    for (size_t i = 0; i < npts; ++i) free(coords[i]);
+    free(coords);
+
 		return Point3D(output[0], output[1], output[2]);
 	}
 

--- a/larcv/core/DataFormat/Voxel3D.h
+++ b/larcv/core/DataFormat/Voxel3D.h
@@ -16,6 +16,7 @@
 
 #include "Voxel.h"
 #include "Voxel3DMeta.h"
+#include "utils.h"
 namespace larcv {
 
   /**
@@ -61,7 +62,8 @@ namespace larcv {
     /// Whether a voxel belongs to this VoxelSet or not, within some distance threshold
     bool within(VoxelID_t id, double distance) const;
     /// Compute PCA of this set of voxels
-	Point3D pca() const;
+  	Point3D pca() const;
+    PCA_3D fit_pca(bool store_spread=true, bool use_true_coord=false);
 
   private:
     larcv::Voxel3DMeta _meta;

--- a/larcv/core/DataFormat/utils.cxx
+++ b/larcv/core/DataFormat/utils.cxx
@@ -1,5 +1,6 @@
 #ifndef __LARCV_UTILS_CXX__
 #define __LARCV_UTILS_CXX__
+#include <algorithm>
 #include "utils.h"
 #include "eigen.h"
 
@@ -65,5 +66,116 @@ void compute_pca(double ** coords, int nfrag, double * output) {
     output[1] = eigenvectors[1][best_idx];
     output[2] = eigenvectors[2][best_idx];
 }
+
+PCA_3D::PCA_3D(const Points_t& points, bool store_spread) 
+{
+  _fit(points.xyz, points.size, store_spread);
 }
+
+PCA_3D::PCA_3D(double **coords, size_t n, bool store_spread)
+{
+  _fit(coords, n, store_spread);
+}
+
+void PCA_3D::_fit(double **coords, size_t n, bool store_spread)
+{
+  _mean.resize(3, 0); 
+  for (size_t k = 0; k < n; ++k) {
+      _mean[0] += coords[k][0];
+      _mean[1] += coords[k][1];
+      _mean[2] += coords[k][2];
+  }
+  _mean[0] /= n;
+  _mean[1] /= n;
+  _mean[2] /= n;
+
+  // Compute local PCA
+  // covariance matrix
+  double M[3][3];
+  for (size_t i1 = 0; i1 < 3; ++i1) {
+      for (size_t i2 = 0; i2 < 3; ++i2) {
+          M[i1][i2] = 0.;
+          for (size_t k = 0; k < n; ++k) {
+              M[i1][i2] = M[i1][i2] + (coords[k][i1] - _mean[i1]) * (coords[k][i2] - _mean[i2]);
+          }
+      }
+  }
+
+  double ev[3];    // unordered eigenvalue
+  double vh[3][3]; // transpose of eig_vec
+  eigen_decomposition(M, vh, ev);
+
+  // argsort eigenvalue
+  std::vector<size_t> idx({0, 1, 2});
+  std::sort(idx.begin(), idx.end(), [&](size_t i, size_t j){return ev[i] > ev[j];});
+    
+  // fill eigenvectors with descending eigenvalues
+  _components.reserve(3);
+  double eig_val[3];
+  for (size_t i = 0; i < 3; ++i){
+    size_t ii = idx[i];
+    eig_val[i] = ev[ii];
+    std::vector<double> vec(3);
+    for (size_t j = 0; j < 3; ++j)
+      vec[j] = vh[j][ii]; // transpose of vh sorted by eigenvalue
+    _components.push_back(std::move(vec));
+  }
+
+  if (store_spread)
+    _spread = find_spread(coords, n, true);
+}
+
+std::vector<double> PCA_3D::find_spread(const Points_t& pts, bool do_transform)
+{
+  return find_spread(pts.xyz, pts.size, do_transform);
+}
+
+std::vector<double> PCA_3D::find_spread(double **input, size_t n, bool do_transform)
+{
+
+  std::vector<double> spread;
+  if (n == 0) return spread;
+
+  Points_t pts(do_transform ? n : 0);
+  if (do_transform) transform(input, pts.xyz, n);
+
+  double** xyz = do_transform ? pts.xyz : input;
+
+  double min_pt[3], max_pt[3];
+  std::copy_n(xyz[0], 3, min_pt);
+  std::copy_n(xyz[0], 3, max_pt);
+
+  for (size_t i_pt = 1; i_pt < n; ++i_pt) {
+    auto& pt = xyz[i_pt];
+    for (size_t i = 0; i < 3; ++i) {
+      if (pt[i] < min_pt[i]) min_pt[i] = pt[i]; 
+      if (pt[i] > max_pt[i]) max_pt[i] = pt[i]; 
+    } //for xyz
+  } // for i_pt
+
+  spread.reserve(3);
+  for (size_t i = 0; i < 3; ++i) 
+    spread.emplace_back(max_pt[i] - min_pt[i]);
+
+  return spread;
+}
+
+void PCA_3D::transform(double **input, double **output, size_t n)
+{
+  for (size_t i_pt = 0; i_pt < n; ++i_pt) {
+    auto& pt = output[i_pt];
+    std::fill_n(pt, 3, 0.);
+    // matrix multiplication
+    for (size_t i = 0; i < 3; ++i)
+      for (size_t j = 0; j < 3; ++j)
+        pt[i] += _components[i][j] * (input[i_pt][j] - _mean[j]);
+  }
+}
+
+void PCA_3D::transform(const Points_t& input, Points_t& output)
+{
+  output.resize(input.size);
+  transform(input.xyz, output.xyz, input.size);
+}
+} // namespace larcv
 #endif

--- a/larcv/core/DataFormat/utils.h
+++ b/larcv/core/DataFormat/utils.h
@@ -10,5 +10,64 @@ namespace larcv {
 	// Compute PCA on coords with shape (nfrag, 3) and stores
 	// eigenvector with largest eigenvalue in output
 	void compute_pca(double ** coords, int nfrag, double * output);
+
+  // PCA class for 3-dim points
+  class PCA_3D {
+    public:
+      // proper handling of 2d array to avoid memory leaks
+      struct Points_t
+      {
+        double **xyz = nullptr;
+        size_t size = 0;
+
+        Points_t(size_t n) { resize(n); }
+
+        Points_t (const Points_t&) = delete;
+        Points_t& operator= (const Points_t&) = delete;
+
+        ~Points_t() { _del(); }
+
+        void resize(size_t n)
+        {
+          if (n == size) return;
+          _del();
+          size = n;
+          xyz = new double*[size];
+          for (size_t i = 0; i < size; ++i) xyz[i] = new double[3];
+        }
+
+        private:
+          void _del()
+          {
+            if (xyz) {
+              for (size_t i = 0 ; i < size; ++i) delete[] xyz[i];
+              delete[] xyz;
+              size = 0;
+            }
+          }
+      }; 
+
+      PCA_3D(const Points_t& points, bool store_spread=false);
+      PCA_3D(double **coords, size_t n, bool store_spread=false);
+
+      void transform(double **input, double **output, size_t n);
+      void transform(const Points_t& input, Points_t& output);
+
+      std::vector<double>
+      find_spread(double** input, size_t n, bool do_transform=false);
+
+      std::vector<double>
+      find_spread(const Points_t& pts, bool do_transform=false);
+
+      const std::vector<double>& get_axis(size_t i) const { return _components.at(i); }
+      const std::vector<double>& get_mean() const { return _mean; }
+      std::vector<double> get_spread() const { return _spread; }
+
+    private:
+      void _fit(double **coords, size_t n, bool store_spread);
+      std::vector<std::vector<double>> _components;
+      std::vector<double> _mean;
+      std::vector<double> _spread;
+  };
 }
 #endif


### PR DESCRIPTION
- More PCA stuff (e.g. 2nd axis, spread ...)
- Fix of memory leak of the original version
- New `SparseTensor::fit_pca(bool store_spread, bool use_true_coord)`

```
// spread along pca1 in voxel units (default)
// for true xyz coordinate (cm), use_true_corrd=true
// if spread is not needed, set store_spread=false for slightly better performance
auto pca = tensor.fit_pca(true);
pca.get_spread()[0];
```
