### PR TITLE
Build voxels from edep-sim TG4HitSegments rather than TG4Trajectories

### DIFF
--- a/larcv/app/Supera/LinkDef.h
+++ b/larcv/app/Supera/LinkDef.h
@@ -15,8 +15,9 @@
 #pragma link C++ class larcv::SuperaBBoxInteraction+;
 #pragma link C++ class larcv::SuperaG4Trajectory+;
 #pragma link C++ class larcv::Vec3f+;
-#pragma link C++ class larcv::Ray+;
-#pragma link C++ class larcv::AABBox+;
+#pragma link C++ class larcv::Vec3d+;
+#pragma link C++ class larcv::Ray<double>+;
+#pragma link C++ class larcv::AABBox<double>+;
 #pragma link C++ class std::vector<std::vector<float> >+;
 //ADD_NEW_CLASS ... do not change this line
 #endif

--- a/larcv/app/Supera/SuperaG4HitSegment.cxx
+++ b/larcv/app/Supera/SuperaG4HitSegment.cxx
@@ -1,0 +1,229 @@
+#ifndef __SUPERAG4HITSEGMENT_CXX__
+#define __SUPERAG4HITSEGMENT_CXX__
+
+#include "SuperaG4HitSegment.h"
+#include "GenRandom.h"
+#include "geometry.h"
+#include "raybox.h"
+namespace larcv {
+
+  static SuperaG4HitSegmentProcessFactory __global_SuperaG4HitSegmentProcessFactory__;
+
+  SuperaG4HitSegment::SuperaG4HitSegment(const std::string name) : SuperaBase(name)
+  { }
+
+  void SuperaG4HitSegment::configure(const PSet& cfg)
+  {
+    SuperaBase::configure(cfg);
+    _sparsetensor3d_producer=cfg.get<std::string>("HitTensorProducer");
+    _particle_producer =cfg.get<std::string>("ParticleProducer");
+  }
+
+  void SuperaG4HitSegment::initialize()
+  {
+    SuperaBase::initialize();
+  }
+
+  bool SuperaG4HitSegment::process(IOManager& mgr)
+  {
+    SuperaBase::process(mgr);
+
+    auto evt = this->GetEvent();
+
+    auto ev_hittensor = (EventSparseTensor3D*)(mgr.get_data("sparse3d", _sparsetensor3d_producer));
+    auto ev_particles = (EventParticle*)(mgr.get_data("particle",_particle_producer));
+
+    std::vector<larcv::Particle> particles;
+    particles.reserve(evt->Trajectories.size());
+    for(auto const& traj : evt->Trajectories) {
+      larcv::Particle part = this->MakeParticle(traj);
+      part.id(ev_particles->as_vector().size());
+      LARCV_INFO() << "Track ID " << part.track_id() << " PDG " << part.pdg_code() << " ... "
+      << "[" << part.first_step().x() << "," << part.first_step().y() << "," << part.first_step().z() << "] => "
+      << "[" << part.last_step().x() << "," << part.last_step().y() << "," << part.last_step().z() << "]" << std::endl;
+      particles.emplace_back(std::move(part));
+      break;
+    }
+
+    larcv::VoxelSet voxelSet;
+    for (auto const & detPair : evt->SegmentDetectors)
+    {
+      larcv::VoxelSet voxels;
+      LARCV_INFO() << "Sensitive detector: " << detPair.first << std::endl;
+      for (auto const & hitSeg : detPair.second)
+      {
+        auto newVoxels = MakeVoxels(hitSeg, ev_hittensor->meta(), particles);
+        LARCV_INFO() << "  Voxel count " << voxels.size() << " value sum " << voxels.sum() << std::endl;
+        for (std::size_t idx = 0; idx < newVoxels.size(); idx++)
+          voxelSet.emplace(std::move(newVoxels[idx]), true);
+      }
+    }
+
+    ev_particles->emplace(std::move(particles));
+    ev_hittensor->emplace(std::move(voxelSet), ev_hittensor->meta());
+
+    return true;
+  }
+
+  void SuperaG4HitSegment::finalize()
+  {}
+
+  larcv::Particle SuperaG4HitSegment::MakeParticle(const TG4Trajectory& part) 
+  {
+    larcv::Particle res;
+    res.track_id(part.GetTrackId());
+    res.pdg_code(part.GetPDGCode());
+    auto const& mom = part.GetInitialMomentum();
+    res.momentum(mom.Px(),mom.Py(),mom.Pz());
+    auto const& start = part.Points.front().GetPosition();
+    res.position(start.X()/10.,start.Y()/10.,start.Z()/10.,start.T());
+    auto const& end = part.Points.back().GetPosition();
+    res.end_position(end.X()/10.,end.Y()/10.,end.Z()/10.,end.T());
+
+
+    // first, last steps, distance travel, energy_deposit, num_voxels
+
+    res.energy_init(mom.E());
+    res.parent_track_id(part.GetParentId());
+
+    return res;
+  }
+
+  void SuperaG4HitSegment::FluctuateEnergy(std::vector<Voxel> &voxels)
+  {
+    // just placeholder for now.
+    return;
+  }
+
+
+  std::vector<larcv::Voxel> SuperaG4HitSegment::MakeVoxels(const ::TG4HitSegment &hitSegment,
+                                                           const larcv::Voxel3DMeta &meta,
+                                                           const std::vector<larcv::Particle> &particles)
+  {
+    std::vector<larcv::Voxel> voxels;
+
+    //std::vector<std::vector<float> > res;
+    //std::vector<float> res_pt(4);
+    const float epsilon = 1.e-4;
+    float dist_travel = 0.;
+    float energy_deposit = 0.;
+    float smallest_side = std::min(meta.size_voxel_x(),std::min(meta.size_voxel_y(),meta.size_voxel_z()));
+    bool first_step_set = false;
+    larcv::AABBox box(meta);
+    LARCV_INFO() <<"World: " << box.bounds[0] << " => " << box.bounds[1] << std::endl;
+
+    const TLorentzVector & start = hitSegment.GetStart();
+    const TLorentzVector & end = hitSegment.GetStop();
+
+    auto const& pos_start = start.Vect();
+    auto const& pos_end   = end.Vect();
+    double tstart = start.T();
+    double tend   = end.T();
+
+    larcv::Vec3f pt0(pos_start);
+    larcv::Vec3f pt1(pos_end);
+    // change unit to cm
+    pt0 /= 10.;
+    pt1 /= 10.;
+
+    larcv::Vec3f dir = pt1 - pt0;
+    auto length = dir.length();
+    dir /= length;
+    larcv::Ray ray(pt0,dir);
+    // 1) check if the start is inside
+    box = larcv::AABBox(meta);
+    LARCV_INFO() <<"Ray: " << ray.orig << " dir " << ray.dir << std::endl;
+    bool skip = false;
+    if(!box.contain(pt0)) {
+      float t0,t1;
+      auto cross = box.intersect(ray,t0,t1);
+      if(cross==0) skip = true;
+      else if(cross==2) {
+        pt0 = pt0 + dir * (t0 + epsilon);
+        tstart = tstart + t0/length * (tend - tstart);
+        length = (pt1 - pt0).length();
+        ray = larcv::Ray(pt0,dir);
+      }
+    }
+
+    if(skip) {
+      LARCV_INFO() << "No crossing point found..." << std::endl;
+      return voxels;
+    }
+
+    voxels.reserve(voxels.size() + (size_t)(length / smallest_side));
+    float t0,t1,dist_section;
+    dist_section = 0.;
+    size_t nx, ny, nz;
+    t0=t1=0.;
+    //size_t ctr=0;
+    while(1) {
+      //ctr += 1;
+      //if(ctr>=10) break;
+      // define the inspection box
+      Vec3f pt = pt0 + dir * (t1 + epsilon);
+      LARCV_DEBUG() << "    New point: " << pt << std::endl;
+      auto vox_id = meta.id((double)(pt.x), (double)(pt.y), (double)(pt.z));
+      if(vox_id==larcv::kINVALID_VOXELID) break;
+      meta.id_to_xyz_index(vox_id, nx, ny, nz);
+      box.bounds[0].x = meta.min_x() + nx * meta.size_voxel_x();
+      box.bounds[0].y = meta.min_y() + ny * meta.size_voxel_y();
+      box.bounds[0].z = meta.min_z() + nz * meta.size_voxel_z();
+      box.bounds[1].x = box.bounds[0].x + meta.size_voxel_x();
+      box.bounds[1].y = box.bounds[0].y + meta.size_voxel_y();
+      box.bounds[1].z = box.bounds[0].z + meta.size_voxel_z();
+      LARCV_DEBUG() << "    Inspecting a voxel id " << vox_id << " ... " << box.bounds[0] << " => " << box.bounds[1] << std::endl;
+      auto cross = box.intersect(ray,t0,t1);
+
+      // no crossing
+      if(cross==0) {
+        LARCV_ERROR() << "      No crossing (not expected) ... breaking" << std::endl;
+        break;
+      }
+      float dx=0;
+      if(cross==1) {
+        LARCV_DEBUG() << "      One crossing: " << dir * t1 << std::endl;
+        dx = std::min(t1,length);
+      }else {
+        LARCV_DEBUG() << "      Two crossing" << dir * t0 << " => " << dir * t1 << std::endl;
+        if(t1>length) dx = length - t0;
+        else dx = t1 - t0;
+      }
+      /*
+      res_pt[0] = (nx+0.5) * meta.size_voxel_x();
+      res_pt[1] = (ny+0.5) * meta.size_voxel_y();
+      res_pt[2] = (nz+0.5) * meta.size_voxel_z();
+      res_pt[3] = dx;
+      res.push_back(res_pt);
+      */
+      float energyInVoxel = dx / length * hitSegment.GetEnergyDeposit();
+      voxels.emplace_back(vox_id, energyInVoxel);
+      dist_travel += dx;
+      dist_section += dx;
+      energy_deposit += energyInVoxel;
+      //LARCV_DEBUG() << "      Registering voxel id " << vox_id << " at distance fraction " << t1/length << std::endl;
+      LARCV_DEBUG() << "      Registering voxel id " << vox_id << " t1 " << t1 << " length " << length << std::endl;
+      if(t1>length) {
+        LARCV_DEBUG() << "      Reached the segment end (t1 = " << t1 << " fractional length " << t1/length << ") ... breaking" << std::endl;
+        break;
+      }
+      LARCV_DEBUG() << "      Updated t1 = " << t1 << " (fractional length " << t1/length << ")" << std::endl;
+    }
+//    // update end position
+//    if(dist_section > 0) {
+//      pt1 = pt0 + dist_section * dir;
+//      tend = tstart + (tend - tstart) / length * dist_section;
+//      particles.last_step(pt1.x, pt1.y, pt1.z, tend);
+//    }
+
+    FluctuateEnergy(voxels);
+
+//    particles.num_voxels(voxels.size());
+//    particles.distance_travel(dist_travel);
+//    particles.energy_deposit(energy_deposit);
+    return voxels;
+  }
+
+}
+
+#endif

--- a/larcv/app/Supera/SuperaG4HitSegment.h
+++ b/larcv/app/Supera/SuperaG4HitSegment.h
@@ -1,0 +1,81 @@
+/**
+ * \file SuperaG4HitSegment.h
+ *
+ * \ingroup Package_Name
+ *
+ * \brief Extract truth info & voxelize true hit segments from edepsim
+ *
+ * @author J. Wolcott <jwolcott@fnal.gov>
+ */
+
+/** \addtogroup Package_Name
+
+    @{*/
+#ifndef __SUPERAG4HITSEGMENT_H__
+#define __SUPERAG4HITSEGMENT_H__
+//#ifndef __CINT__
+//#ifndef __CLING__
+#include "SuperaBase.h"
+#include "EDepSim/TG4Event.h"
+#include "larcv/core/DataFormat/EventParticle.h"
+#include "larcv/core/DataFormat/EventVoxel3D.h"
+namespace larcv {
+
+  /**
+     \class SuperaG4HitSegment
+     Responsible for defining a rectangular volume boundary and voxelization
+  */
+  class SuperaG4HitSegment : public SuperaBase {
+
+  public:
+
+    /// Default constructor
+    SuperaG4HitSegment(const std::string name = "SuperaG4HitSegment");
+
+    /// Default destructor
+    ~SuperaG4HitSegment() {}
+
+    void configure(const PSet&);
+
+    void initialize();
+
+    bool process(IOManager& mgr);
+
+    void finalize();
+
+  private:
+      /// Apply Landau fluctuations to the set of energies in these voxels
+      void FluctuateEnergy(std::vector<Voxel> &voxels);
+
+      larcv::Particle MakeParticle(const TG4Trajectory&);
+
+      std::vector<larcv::Voxel>
+      MakeVoxels(const ::TG4HitSegment &hitSegment,
+                 const larcv::Voxel3DMeta &meta,
+                 const std::vector<larcv::Particle> &particles);
+
+    std::string _sparsetensor3d_producer;
+    std::string _particle_producer;
+
+  };
+
+  /**
+     \class larcv::SuperaBBoxInteractionFactory
+     \brief A concrete factory class for larcv::SuperaG4HitSegment
+  */
+  class SuperaG4HitSegmentProcessFactory : public ProcessFactoryBase {
+  public:
+    /// ctor
+    SuperaG4HitSegmentProcessFactory() { ProcessFactory::get().add_factory("SuperaG4HitSegment", this); }
+    /// dtor
+    ~SuperaG4HitSegmentProcessFactory() {}
+    /// creation method
+    ProcessBase* create(const std::string instance_name) { return new SuperaG4HitSegment(instance_name); }
+  };
+
+}
+//#endif
+//#endif
+#endif
+/** @} */ // end of doxygen group
+

--- a/larcv/app/Supera/SuperaG4HitSegment.h
+++ b/larcv/app/Supera/SuperaG4HitSegment.h
@@ -19,7 +19,17 @@
 #include "EDepSim/TG4Event.h"
 #include "larcv/core/DataFormat/EventParticle.h"
 #include "larcv/core/DataFormat/EventVoxel3D.h"
+
+// forward declarations
+class TVector3;
+
 namespace larcv {
+
+  class AABBox;
+
+  template <typename T>
+  class Vec3;
+  typedef Vec3<float> Vec3f;
 
   /**
      \class SuperaG4HitSegment
@@ -47,12 +57,29 @@ namespace larcv {
       /// Apply Landau fluctuations to the set of energies in these voxels
       void FluctuateEnergy(std::vector<Voxel> &voxels);
 
-      larcv::Particle MakeParticle(const TG4Trajectory&);
+      /// Where (if anywhere) does a line segment intersect a given bounding box?
+      /// (If the entire line segment is contained, the entry and exit points
+      ///  will be set to the start and stop points provided.)
+      ///
+      /// \param bbox        Bounding box in question
+      /// \param startPoint  Start point of the line segment in question
+      /// \param stopPoint   Stop point of the line segment in question
+      /// \param entryPoint  Computed entry point of the line segment into the box, if any
+      /// \param exitPoint   Computed exit point of the line segment from the box, if any
+      /// \return            Number of intersections (will be 0, 1, or 2)
+      char Intersections(const larcv::AABBox & bbox,
+                         const TVector3 & startPoint,
+                         const TVector3 & stopPoint,
+                         larcv::Vec3f & entryPoint,
+                         larcv::Vec3f & exitPoint) const;
+
+      larcv::Particle MakeParticle(const TG4Trajectory& traj,
+                                   const larcv::AABBox& bbox);
 
       std::vector<larcv::Voxel>
       MakeVoxels(const ::TG4HitSegment &hitSegment,
                  const larcv::Voxel3DMeta &meta,
-                 const std::vector<larcv::Particle> &particles);
+                 std::vector<larcv::Particle> &particles);
 
     std::string _sparsetensor3d_producer;
     std::string _particle_producer;

--- a/larcv/app/Supera/SuperaG4HitSegment.h
+++ b/larcv/app/Supera/SuperaG4HitSegment.h
@@ -25,11 +25,13 @@ class TVector3;
 
 namespace larcv {
 
+  template <typename T>
   class AABBox;
 
   template <typename T>
   class Vec3;
   typedef Vec3<float> Vec3f;
+  typedef Vec3<double> Vec3d;
 
   /**
      \class SuperaG4HitSegment
@@ -67,14 +69,15 @@ namespace larcv {
       /// \param entryPoint  Computed entry point of the line segment into the box, if any
       /// \param exitPoint   Computed exit point of the line segment from the box, if any
       /// \return            Number of intersections (will be 0, 1, or 2)
-      char Intersections(const larcv::AABBox & bbox,
+      template <typename T>
+      char Intersections(const larcv::AABBox<T> & bbox,
                          const TVector3 & startPoint,
                          const TVector3 & stopPoint,
-                         larcv::Vec3f & entryPoint,
-                         larcv::Vec3f & exitPoint) const;
+                         larcv::Vec3<T> & entryPoint,
+                         larcv::Vec3<T> & exitPoint) const;
 
       larcv::Particle MakeParticle(const TG4Trajectory& traj,
-                                   const larcv::AABBox& bbox);
+                                   const larcv::AABBox<double>& bbox);
 
       std::vector<larcv::Voxel>
       MakeVoxels(const ::TG4HitSegment &hitSegment,

--- a/larcv/app/Supera/geometry.h
+++ b/larcv/app/Supera/geometry.h
@@ -125,6 +125,7 @@ template<typename T>
 // you can declare a vector either that way: Vec3<float> a, or that way: Vec3f a
 //[/comment]
     typedef Vec3<float> Vec3f;
+    typedef Vec3<double> Vec3d;
     typedef Vec3<int> Vec3i;
 
 }

--- a/larcv/app/Supera/geometry.h
+++ b/larcv/app/Supera/geometry.h
@@ -65,6 +65,8 @@ template<typename T>
         Vec3(const TLorentzVector& v) : x(v.X()), y(v.Y()), z(v.Z()) {}
         Vec3 operator + (const Vec3 &v) const
         { return Vec3(x + v.x, y + v.y, z + v.z); }
+        Vec3 & operator += (const Vec3 &v)
+        { x += v.x; y += v.y; z += v.z; return *this; }
         Vec3 operator - (const Vec3 &v) const
         { return Vec3(x - v.x, y - v.y, z - v.z); }
         Vec3 operator - () const

--- a/larcv/app/Supera/raybox.h
+++ b/larcv/app/Supera/raybox.h
@@ -75,7 +75,7 @@ namespace larcv {
             return 2;
         } 
 
-        bool contain(const Vec3f& pt) {
+        bool contain(const Vec3f& pt) const {
             return (bounds[0].x <= pt.x && pt.x < bounds[1].x &&
                 bounds[0].y <= pt.y && pt.y < bounds[1].y &&
                 bounds[0].z <= pt.z && pt.z < bounds[1].z);

--- a/larcv/app/Supera/raybox.h
+++ b/larcv/app/Supera/raybox.h
@@ -10,26 +10,28 @@
 
 namespace larcv {
 
+    template <typename T>
     class Ray 
     { 
     public: 
-        Ray(const Vec3f &orig, const Vec3f &dir) : orig(orig), dir(dir) 
+        Ray(const Vec3<T> &orig, const Vec3<T> &dir) : orig(orig), dir(dir)
         { 
             invdir = 1 / dir; 
             sign[0] = (invdir.x < 0); 
             sign[1] = (invdir.y < 0); 
             sign[2] = (invdir.z < 0); 
         } 
-        Vec3f orig, dir; // ray orig and dir 
-        Vec3f invdir; 
+        Vec3<T> orig, dir; // ray orig and dir
+        Vec3<T> invdir;
         int sign[3]; 
     }; 
 
+    template <typename T>
     class AABBox 
     { 
     public: 
-        AABBox(const Vec3f &b0, const Vec3f &b1) { bounds[0] = b0, bounds[1] = b1; } 
-        AABBox(const float x0, const float y0, const float z0, const float x1, const float y1, const float z1)
+        AABBox(const Vec3<T> &b0, const Vec3<T> &b1) { bounds[0] = b0, bounds[1] = b1; }
+        AABBox(const T x0, const T y0, const T z0, const T x1, const T y1, const T z1)
         {
             bounds[0].x=x0; bounds[0].y=y0; bounds[0].z=z0;
             bounds[1].x=x1; bounds[1].y=y1; bounds[1].z=z1;
@@ -39,9 +41,9 @@ namespace larcv {
             bounds[0].x=box.min_x(); bounds[0].y=box.min_y(); bounds[0].z=box.min_z(); 
             bounds[1].x=box.max_x(); bounds[1].y=box.max_y(); bounds[1].z=box.max_z();
         }
-        int intersect(const Ray &r, float& t0, float& t1) const 
+        int intersect(const Ray<T> &r, T& t0, T& t1) const
         { 
-            float tmin, tmax, tymin, tymax, tzmin, tzmax; 
+            T tmin, tmax, tymin, tymax, tzmin, tzmax;
 
             tmin = (bounds[r.sign[0]].x - r.orig.x) * r.invdir.x; 
             tmax = (bounds[1-r.sign[0]].x - r.orig.x) * r.invdir.x; 
@@ -75,13 +77,13 @@ namespace larcv {
             return 2;
         } 
 
-        bool contain(const Vec3f& pt) const {
+        bool contain(const Vec3<T>& pt) const {
             return (bounds[0].x <= pt.x && pt.x < bounds[1].x &&
                 bounds[0].y <= pt.y && pt.y < bounds[1].y &&
                 bounds[0].z <= pt.z && pt.z < bounds[1].z);
         }
 
-        Vec3f bounds[2]; 
+        Vec3<T> bounds[2];
     }; 
 
 }

--- a/larcv/app/Supera/run_supera.py
+++ b/larcv/app/Supera/run_supera.py
@@ -21,10 +21,12 @@ if len(sys.argv) > 2:
 		if not argv.endswith('.root'): continue
 		print('Adding input:',argv)
 		ch.AddFile(argv)
-event_range = range(proc.batch_start_entry(), proc.batch_start_entry() + proc.batch_num_entry()) \
+print("Chain has", ch.GetEntries(), "entries")
+event_range = (proc.batch_start_entry(), proc.batch_start_entry() + proc.batch_num_entry()) \
 	if proc.batch_num_entry() > 0 \
-	else range(ch.GetEntries())
-print('Processing', len(event_range), 'events')
+	else (0, ch.GetEntries())
+print('Processing', event_range[1] - event_range[0], 'events')
+sys.stdout.flush()
 
 # Initialize and retrieve a list of processes that belongs to SuperaBase inherited module classes
 proc.initialize()
@@ -37,8 +39,9 @@ for name in proc.process_names():
 		supera_procs.append(pid)
 
 # Event loop
-for entry in event_range:
+for entry in range(*event_range):
 	print("considering event:", entry)
+	sys.stdout.flush()
 	ch.GetEntry(entry)
 
 	ev = ch.Event 

--- a/larcv/app/Supera/run_supera.py
+++ b/larcv/app/Supera/run_supera.py
@@ -21,7 +21,10 @@ if len(sys.argv) > 2:
 		if not argv.endswith('.root'): continue
 		print('Adding input:',argv)
 		ch.AddFile(argv)
-print('Processing',ch.GetEntries(),'events')
+event_range = range(proc.batch_start_entry(), proc.batch_start_entry() + proc.batch_num_entry()) \
+	if proc.batch_num_entry() > 0 \
+	else range(ch.GetEntries())
+print('Processing', len(event_range), 'events')
 
 # Initialize and retrieve a list of processes that belongs to SuperaBase inherited module classes
 proc.initialize()
@@ -32,9 +35,10 @@ for name in proc.process_names():
 	if getattr(module,'is')('Supera'):
 		print('Running a Supera module:',name)
 		supera_procs.append(pid)
-# Event loop
-for entry in range(ch.GetEntries()):
 
+# Event loop
+for entry in event_range:
+	print("considering event:", entry)
 	ch.GetEntry(entry)
 
 	ev = ch.Event 
@@ -47,5 +51,4 @@ for entry in range(ch.GetEntries()):
 		module.SetEvent(ev)
 
 	proc.process_entry()
-	break
 proc.finalize()

--- a/larcv/app/Supera/supera-ndlar.cfg
+++ b/larcv/app/Supera/supera-ndlar.cfg
@@ -1,0 +1,40 @@
+ProcessDriver: {
+
+  Verbosity:    2
+  EnableFilter: false
+  RandomAccess: false
+#   ProcessType:  ["SuperaBBoxInteraction","SuperaG4Trajectory","Tensor3DFromCluster3D"]
+#   ProcessName:  ["SuperaBBoxInteraction","SuperaG4Trajectory","Tensor3DFromCluster3D"]
+  ProcessType:  ["SuperaBBoxInteraction","SuperaG4HitSegment"]
+  ProcessName:  ["SuperaBBoxInteraction","SuperaG4HitSegment"]
+  AnaFile:     ""
+  StartEntry: 0
+  NumEntries: 0
+  
+  IOManager: {
+    Verbosity:   10
+    Name:        "IOManager"
+    IOMode:      1
+    OutFileName: "supera.root"
+  }
+
+  ProcessList: {
+    SuperaBBoxInteraction: {
+      Verbosity: 1
+      Cluster3DLabels: ["geant4"]
+      Tensor3DLabels:  ["geant4"]
+#      BBoxSize: [454.0416,454.0416,454.0416]  # voxelize
+      BBoxSize: [14529.3, 14529.3, 14529.3]
+      VoxelSize: [0.4434,0.4434,0.4434]
+      BBoxTop: [7264.6656, 7264.6656, 14529.3312]
+      BBoxBottom: [-7264.6656, -7264.6656, 0]
+#       BBoxTop: [447.0208,30.,877.0208]
+#       BBoxBottom: [220,-197.0208,650]
+    }
+    SuperaG4HitSegment: {
+      Verbosity: 3
+      HitTensorProducer: "geant4"
+      ParticleProducer:  "geant4"
+    }
+  }
+}

--- a/larcv/core/Processor/ProcessDriver.h
+++ b/larcv/core/Processor/ProcessDriver.h
@@ -99,6 +99,9 @@ namespace larcv {
     /// Returns true if after any entry is processed (process_entry/batch_process) but not yet finalized
     inline bool processing() const { return _processing; }
 
+    inline size_t batch_start_entry() const { return _batch_start_entry; }
+    inline size_t batch_num_entry() const { return _batch_num_entry; }
+
   private:
 
     bool _process_entry_();


### PR DESCRIPTION
edep-sim produces two output products: `TG4Trajectory` (corresponds to an individual true particle track) and `TG4HitSegment` (energy deposited in designated 'sensitive' geometry volumes).  Until we have the full detector response & charge simulation, we want to use the HitSegments as our voxelation input, because these tell us how much energy actually went where.

This PR adds a new class, `SuperaG4HitSegment`, which can be used with `run_supera.py` and a configuration like the sample `supera-ndlar.cfg`, to do so.