### PR TITLE
Use larger storage type for particle & interaction IDs

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -23,13 +23,14 @@ if [[ -z $LARCV_BUILDDIR ]]; then
 fi
 
 # Check python version compatibility:
-export LARCV_PYTHON_CONFIG=python-config
 LARCV_PYVERSION=0
 if [ `command -v python3` ]; then
     export LARCV_PYTHON=`which python3`
+    export LARCV_PYTHON_CONFIG=`which python3-config`
     LARCV_PYVERSION=$($LARCV_PYTHON -c "import sys; print(sys.version_info.major)")
 else
     export LARCV_PYTHON=`which python`
+    export LARCV_PYTHON_CONFIG=`which python-config`
     LARCV_PYVERSION=$($LARCV_PYTHON -c "import sys; print(sys.version_info.major)")
 fi
 if [[ $LARCV_PYVERSION -gt 2 ]]

--- a/larcv/core/Base/LArCVTypes.h
+++ b/larcv/core/Base/LArCVTypes.h
@@ -33,6 +33,8 @@
 namespace larcv {
 
   /// Used as an invalid value identifier for long long
+  /// Used as an invalid value identifier for unsigned long long
+  const unsigned long      kINVALID_ULONG     = std::numeric_limits< unsigned long >::max();
   const long long          kINVALID_LONGLONG  = std::numeric_limits< long long          >::max();
   /// Used as an invalid value identifier for unsigned long long
   const unsigned long long kINVALID_ULONGLONG = std::numeric_limits< unsigned long long >::max();

--- a/larcv/core/DataFormat/DataFormatTypes.h
+++ b/larcv/core/DataFormat/DataFormatTypes.h
@@ -19,9 +19,9 @@ namespace larcv {
   /// "ID" of MCTruth in terms of its index number in the collection std::vector
   typedef unsigned short MCTIndex_t;
   /// "ID" for a set of elements
-  typedef unsigned short InstanceID_t;
+  typedef unsigned long InstanceID_t;
   /// Invalid rep for InstanceID_t
-  static const unsigned short kINVALID_INSTANCEID = kINVALID_USHORT;
+  static const unsigned long kINVALID_INSTANCEID = kINVALID_ULONG;
   /// Invalid projection id
   static const ProjectionID_t kINVALID_PROJECTIONID = kINVALID_USHORT;
 


### PR DESCRIPTION
The DUNE 2x2 and ND uses of larcv produce very large Particle and Interaction IDs (the former because an extremely large number of true particles are simulated; the latter because the interaction ID encodes the GENIE file it came from).  In order to store them successfully without wrapping we promote the basic type to be larger.