### PR TITLE
use the SIGNED long int val for `invalid instance`

### DIFF
--- a/larcv/core/DataFormat/DataFormatTypes.h
+++ b/larcv/core/DataFormat/DataFormatTypes.h
@@ -21,7 +21,9 @@ namespace larcv {
   /// "ID" for a set of elements
   typedef unsigned long InstanceID_t;
   /// Invalid rep for InstanceID_t
-  static const unsigned long kINVALID_INSTANCEID = kINVALID_ULONG;
+  // yes, SIGNED long.  this is because numpy's int64 (which this will get converted to when used with mlreco3d)
+  // isn't big enough for the unsigned long long value, but it *is* big enough for this one
+  static const unsigned long kINVALID_INSTANCEID = kINVALID_LONGLONG;
   /// Invalid projection id
   static const ProjectionID_t kINVALID_PROJECTIONID = kINVALID_USHORT;
 


### PR DESCRIPTION
Otherwise, when the invalid value is written out to storage via mlreco3d on the other end of the pipeline, we'll run into a `OverflowError: Python int too large to convert to C long` because of a mismatch between numpy.int64 and unsigned long long.

This choice exposes us to a possible niche bug where we might overflow past this invalid value if there are more than approximately 9e18 instances, but that's a risk worth taking :)