### PR TITLE
new product for propagating info about triggers

### DIFF
--- a/larcv/core/DataFormat/EventTrigger.cxx
+++ b/larcv/core/DataFormat/EventTrigger.cxx
@@ -1,0 +1,12 @@
+#ifndef EVENTTRIGGERCXX
+#define EVENTTRIGGERCXX
+
+#include "EventTrigger.h"
+
+namespace larcv{
+  /// Global larcv::SBClusterFactory to register ClusterAlgoFactory
+  static EventTriggerFactory __global_EventTriggerFactory__;
+
+}
+
+#endif

--- a/larcv/core/DataFormat/EventTrigger.h
+++ b/larcv/core/DataFormat/EventTrigger.h
@@ -1,0 +1,64 @@
+/**
+ * \file EventTrigger.h
+ *
+ * \ingroup DataFormat
+ *
+ * \brief Wrapper for making Trigger persistable
+ *
+ * @author J. Wolcott <jwolcott@fnal.gov
+ */
+
+/** \addtogroup DataFormat
+
+    @{*/
+#ifndef __LARCV_EVENTTRIGGER_H__
+#define __LARCV_EVENTTRIGGER_H__
+
+#include "EventBase.h"
+#include "Trigger.h"
+#include "DataProductFactory.h"
+
+namespace larcv {
+  /**
+    \class EventTrigger
+    Persistent storage for trigger-related data
+  */
+  class EventTrigger : public EventBase, public larcv::Trigger
+  {
+    public:
+
+      /// Data clear method
+      inline void clear()
+      { EventBase::clear(); Trigger::clear(); }
+
+  };
+}
+
+#include "IOManager.h"
+namespace larcv {
+
+  // Template instantiation for IO
+  template<> inline std::string product_unique_name<larcv::EventTrigger>() { return "trigger"; }
+  template EventTrigger& IOManager::get_data<larcv::EventTrigger>(const std::string&);
+  template EventTrigger& IOManager::get_data<larcv::EventTrigger>(const ProducerID_t);
+
+  /**
+     \class larcv::EventTriggerFactory
+     \brief A concrete factory class for larcv::EventTrigger
+  */
+  class EventTriggerFactory : public DataProductFactoryBase {
+  public:
+    /// ctor
+    EventTriggerFactory()
+    { DataProductFactory::get().add_factory(product_unique_name<larcv::EventTrigger>(),this); }
+    /// dtor
+    ~EventTriggerFactory() {}
+    /// create method
+    EventBase* create() { return new EventTrigger; }
+  };
+
+
+}
+
+#endif
+/** @} */ // end of doxygen group

--- a/larcv/core/DataFormat/LinkDef.h
+++ b/larcv/core/DataFormat/LinkDef.h
@@ -84,6 +84,9 @@
 #pragma link C++ class larcv::Meta+;
 #pragma link C++ class larcv::EventMeta+;
 
+#pragma link C++ class larcv::Trigger+;
+#pragma link C++ class larcv::EventTrigger+;
+
 #pragma link C++ class larcv::FlatTensorContents+;
 #pragma link C++ function larcv::as_image2d(const SparseTensor2D&)+;
 #pragma link C++ function larcv::as_image2d(const VoxelSet&, const ImageMeta&)+;

--- a/larcv/core/DataFormat/Trigger.h
+++ b/larcv/core/DataFormat/Trigger.h
@@ -1,0 +1,56 @@
+/**
+ * \file Trigger.h
+ *
+ * \ingroup core_DataFormat
+ *
+ * \brief Storage for information about detector trigger that created this image
+ *
+ * @author J. Wolcott <jwolcott@fnal.gov>
+ */
+
+/** \addtogroup core_DataFormat
+
+    @{*/
+#ifndef __LARCV_TRIGGER_H__
+#define __LARCV_TRIGGER_H__
+
+#include "DataFormatTypes.h"
+#include <vector>
+
+namespace larcv {
+    /**
+       \class Trigger
+       \brief Storage for information about detector trigger that created this image
+    */
+    class Trigger {
+
+    public:
+        /// Default constructor
+        Trigger(InstanceID_t id=kINVALID_INSTANCEID, unsigned long long time_s=kINVALID_ULONGLONG, unsigned int time_ns=kINVALID_UINT, int type=kINVALID_INT)
+          : _id(id), _time_s(time_s), _time_ns(time_ns), _type(type)
+        {}
+
+        void clear()   { _id = kINVALID_INSTANCEID; _time_s = kINVALID_ULONGLONG; _time_ns = kINVALID_UINT; _type = kINVALID_INT; }
+
+        // accessors
+        InstanceID_t       id()      const { return _id; };
+        unsigned long long time_s()  const { return _time_s; }
+        unsigned int       time_ns() const { return _time_ns; }
+        int                type()    const { return _type; }
+
+        // setters
+        void id(InstanceID_t id)               { _id = id; };
+        void time_s(unsigned long long time_s) { _time_s = time_s; }
+        void time_ns(unsigned int time_ns)     { _time_ns = time_ns; }
+        void type(unsigned int typ)            { _type = typ; }
+
+     private:
+        InstanceID_t       _id;       ///< Trigger ID, if relevant
+        unsigned long long _time_s;   ///< Integer seconds part of UNIX time this trigger was initiated
+        unsigned int       _time_ns;  ///< Fractional part of UNIX time this trigger was initiated, measured in ns
+        int                _type;     ///< DAQ-specific trigger type
+    };
+}
+
+#endif // __LARCV_TRIGGER_H__
+/** @} */ // end of doxygen group


### PR DESCRIPTION
In the context of DUNE 2x2 (and later, full ND-LAr) we need to be able to match up events between the TPC and and adjacent spectrometer (MINERvA for 2x2; TMS or ND-GAr for ND-LAr).  Because the DAQs for those will not necessarily be run in a coordinated way (in particular, there is no reason to expect that event numbers will align, given the detectors will need to be started and stopped separately, and have different capabilities for how they can be triggered), the data stream itself needs to provide some way of matching them up.

This PR adds a simple mechanism for propagating basic info that can be used for matching.  It supposes that the most fundamental unit is the "trigger"---the signal beginning of a readout.  It carries: the time the trigger came, a trigger ID associated with it (probably the same as the event number, but is not forced to be), and a trigger "type" field that can be used independently for each detector.  The expectation is that matching will primarily be done using the trigger time.