### PR TITLE
add a field for propagating "original generator ID"

### DIFF
--- a/larcv/core/DataFormat/EventTrigger.cxx
+++ b/larcv/core/DataFormat/EventTrigger.cxx
@@ -1,0 +1,12 @@
+#ifndef EVENTTRIGGERCXX
+#define EVENTTRIGGERCXX
+
+#include "EventTrigger.h"
+
+namespace larcv{
+  /// Global larcv::SBClusterFactory to register ClusterAlgoFactory
+  static EventTriggerFactory __global_EventTriggerFactory__;
+
+}
+
+#endif

--- a/larcv/core/DataFormat/EventTrigger.h
+++ b/larcv/core/DataFormat/EventTrigger.h
@@ -1,0 +1,64 @@
+/**
+ * \file EventTrigger.h
+ *
+ * \ingroup DataFormat
+ *
+ * \brief Wrapper for making Trigger persistable
+ *
+ * @author J. Wolcott <jwolcott@fnal.gov
+ */
+
+/** \addtogroup DataFormat
+
+    @{*/
+#ifndef __LARCV_EVENTTRIGGER_H__
+#define __LARCV_EVENTTRIGGER_H__
+
+#include "EventBase.h"
+#include "Trigger.h"
+#include "DataProductFactory.h"
+
+namespace larcv {
+  /**
+    \class EventTrigger
+    Persistent storage for trigger-related data
+  */
+  class EventTrigger : public EventBase, public larcv::Trigger
+  {
+    public:
+
+      /// Data clear method
+      inline void clear()
+      { EventBase::clear(); Trigger::clear(); }
+
+  };
+}
+
+#include "IOManager.h"
+namespace larcv {
+
+  // Template instantiation for IO
+  template<> inline std::string product_unique_name<larcv::EventTrigger>() { return "trigger"; }
+  template EventTrigger& IOManager::get_data<larcv::EventTrigger>(const std::string&);
+  template EventTrigger& IOManager::get_data<larcv::EventTrigger>(const ProducerID_t);
+
+  /**
+     \class larcv::EventTriggerFactory
+     \brief A concrete factory class for larcv::EventTrigger
+  */
+  class EventTriggerFactory : public DataProductFactoryBase {
+  public:
+    /// ctor
+    EventTriggerFactory()
+    { DataProductFactory::get().add_factory(product_unique_name<larcv::EventTrigger>(),this); }
+    /// dtor
+    ~EventTriggerFactory() {}
+    /// create method
+    EventBase* create() { return new EventTrigger; }
+  };
+
+
+}
+
+#endif
+/** @} */ // end of doxygen group

--- a/larcv/core/DataFormat/LinkDef.h
+++ b/larcv/core/DataFormat/LinkDef.h
@@ -84,6 +84,9 @@
 #pragma link C++ class larcv::Meta+;
 #pragma link C++ class larcv::EventMeta+;
 
+#pragma link C++ class larcv::Trigger+;
+#pragma link C++ class larcv::EventTrigger+;
+
 #pragma link C++ class larcv::FlatTensorContents+;
 #pragma link C++ function larcv::as_image2d(const SparseTensor2D&)+;
 #pragma link C++ function larcv::as_image2d(const VoxelSet&, const ImageMeta&)+;

--- a/larcv/core/DataFormat/Particle.h
+++ b/larcv/core/DataFormat/Particle.h
@@ -37,6 +37,7 @@ namespace larcv {
       , _current_type     (-1)
       , _interaction_type (-1)
       , _trackid          (kINVALID_UINT)
+      , _genid            (kINVALID_UINT)
       , _pdg              (0)
       , _px               (0.)
       , _py               (0.)
@@ -70,6 +71,7 @@ namespace larcv {
     inline short nu_interaction_type () const { return _interaction_type; }
     // particle's info getter
     inline unsigned int track_id   () const { return _trackid;    }
+    inline unsigned int gen_id     () const { return _genid;      }
     inline int          pdg_code   () const { return _pdg;        }
     inline double       px         () const { return _px;         }
     inline double       py         () const { return _py;         }
@@ -130,6 +132,7 @@ namespace larcv {
     inline void nu_interaction_type (short itype) {_interaction_type = itype; }
     // particle's info setter
     inline void track_id        (unsigned int id )   { _trackid = id;       }
+    inline void gen_id          (unsigned int id )   { _genid = id;       }
     inline void pdg_code        (int code)           { _pdg = code;         }
     inline void momentum        (double px, double py, double pz) { _px = px; _py = py; _pz = pz; }
     inline void position        (const larcv::Vertex& vtx) { _vtx = vtx;    }
@@ -181,6 +184,7 @@ namespace larcv {
     short _interaction_type;   ///< if neutrino, shows interaction GENIE code. else kINVALID_USHORT
 
     unsigned int _trackid;     ///< Geant4 track id
+    unsigned int _genid;       ///< Original generator ID, if different from Geant4 one (e.g.: GENIE particle ID)
     int          _pdg;         ///< PDG code
     double       _px,_py,_pz;  ///< (x,y,z) component of particle's initial momentum
     Vertex       _vtx;         ///< (x,y,z,t) of particle's vertex information

--- a/larcv/core/DataFormat/Trigger.h
+++ b/larcv/core/DataFormat/Trigger.h
@@ -1,0 +1,56 @@
+/**
+ * \file Trigger.h
+ *
+ * \ingroup core_DataFormat
+ *
+ * \brief Storage for information about detector trigger that created this image
+ *
+ * @author J. Wolcott <jwolcott@fnal.gov>
+ */
+
+/** \addtogroup core_DataFormat
+
+    @{*/
+#ifndef __LARCV_TRIGGER_H__
+#define __LARCV_TRIGGER_H__
+
+#include "DataFormatTypes.h"
+#include <vector>
+
+namespace larcv {
+    /**
+       \class Trigger
+       \brief Storage for information about detector trigger that created this image
+    */
+    class Trigger {
+
+    public:
+        /// Default constructor
+        Trigger(InstanceID_t id=kINVALID_INSTANCEID, unsigned long long time_s=kINVALID_ULONGLONG, unsigned int time_ns=kINVALID_UINT, int type=kINVALID_INT)
+          : _id(id), _time_s(time_s), _time_ns(time_ns), _type(type)
+        {}
+
+        void clear()   { _id = kINVALID_INSTANCEID; _time_s = kINVALID_ULONGLONG; _time_ns = kINVALID_UINT; _type = kINVALID_INT; }
+
+        // accessors
+        InstanceID_t       id()      const { return _id; };
+        unsigned long long time_s()  const { return _time_s; }
+        unsigned int       time_ns() const { return _time_ns; }
+        int                type()    const { return _type; }
+
+        // setters
+        void id(InstanceID_t id)               { _id = id; };
+        void time_s(unsigned long long time_s) { _time_s = time_s; }
+        void time_ns(unsigned int time_ns)     { _time_ns = time_ns; }
+        void type(unsigned int typ)            { _type = typ; }
+
+     private:
+        InstanceID_t       _id;       ///< Trigger ID, if relevant
+        unsigned long long _time_s;   ///< Integer seconds part of UNIX time this trigger was initiated
+        unsigned int       _time_ns;  ///< Fractional part of UNIX time this trigger was initiated, measured in ns
+        int                _type;     ///< DAQ-specific trigger type
+    };
+}
+
+#endif // __LARCV_TRIGGER_H__
+/** @} */ // end of doxygen group


### PR DESCRIPTION
This field will correspond to the original generator (read: GENIE)'s track index. In DUNE 2x2, the edep-sim step of the simulation renumbers the ids that wind up in trackid. Not having the original GENIE index makes some truth matching difficult.