### PR TITLE
Minor fixes

### DIFF
--- a/larcv/core/DataFormat/Flash.cxx
+++ b/larcv/core/DataFormat/Flash.cxx
@@ -8,7 +8,7 @@
 namespace larcv {
 
     Flash::Flash(double time, double timeWidth, double absTime, unsigned int frame,
-        std::vector<double> PEPerOpDet, unsigned int tpc,
+        std::vector<double> PEPerOpDet, unsigned int volume_id,
         bool inBeamFrame, int onBeamTime, double fastToTotal,
         double xCenter, double xWidth,
         double yCenter, double yWidth,
@@ -18,7 +18,7 @@ namespace larcv {
         InstanceID_t id)
         : _id(id)
         , _time(time)
-        , _tpc(tpc)
+        , _volume_id(volume_id)
         , _timeWidth(timeWidth)
         , _absTime  (absTime)
         , _frame    (frame)

--- a/larcv/core/DataFormat/Flash.h
+++ b/larcv/core/DataFormat/Flash.h
@@ -28,7 +28,7 @@ namespace larcv {
 
         /// Default constructor
         Flash(double time=0, double timeWidth=0, double absTime=0, unsigned int frame=0,
-            std::vector<double> PEPerOpDet=std::vector<double>(0), unsigned int tpc=100,
+            std::vector<double> PEPerOpDet=std::vector<double>(0), unsigned int volume_id=100,
             bool inBeamFrame=0, int onBeamTime=0, double fastToTotal=1,
             double xCenter=0, double xWidth=0,
             double yCenter=0, double yWidth=0,
@@ -45,7 +45,7 @@ namespace larcv {
         /// Getters
         inline InstanceID_t id         () const { return _id;         }
         inline double time () const { return _time; }
-        inline unsigned int tpc () const { return _tpc; }
+        inline unsigned int volume_id () const { return _volume_id; }
         inline double timeWidth () const { return _timeWidth; }
         inline double absTime () const { return _absTime; }
         inline unsigned int frame () const { return _frame; }
@@ -65,7 +65,7 @@ namespace larcv {
         /// Setters
         inline void id (InstanceID_t id  )  { _id = id;         }
         inline void time (double time) { _time = time; }
-        inline void tpc (unsigned int tpc) { _tpc = tpc; }
+        inline void volume_id (unsigned int volume_id) { _volume_id = volume_id; }
         inline void timeWidth (double timeWidth) { _timeWidth = timeWidth; }
         inline void absTime (double absTime) { _absTime = absTime; }
         inline void frame (unsigned int frame) { _frame = frame; }
@@ -88,7 +88,7 @@ namespace larcv {
 
         InstanceID_t   _id; ///< "ID" of this flash in FlashSet collection
         double _time; ///< Time on @ref DetectorClocksHardwareTrigger "trigger time scale" [us]
-        unsigned int _tpc; ///< ID of the hit TPC (0-7)
+        unsigned int _volume_id; ///< ID of the hit TPC (0-7)
         double _timeWidth; ///< Width of the flash in time [us]
         double _absTime; ///< Time by PMT readout clock
         unsigned int _frame; ///< Frame number

--- a/larcv/core/DataFormat/Particle.h
+++ b/larcv/core/DataFormat/Particle.h
@@ -37,7 +37,6 @@ namespace larcv {
       , _current_type     (-1)
       , _interaction_type (-1)
       , _trackid          (kINVALID_UINT)
-      , _genid            (kINVALID_UINT)
       , _pdg              (0)
       , _px               (0.)
       , _py               (0.)
@@ -74,7 +73,6 @@ namespace larcv {
     inline short nu_interaction_type () const { return _interaction_type; }
     // particle's info getter
     inline unsigned int track_id   () const { return _trackid;    }
-    inline unsigned int gen_id     () const { return _genid;      }
     inline int          pdg_code   () const { return _pdg;        }
     inline double       px         () const { return _px;         }
     inline double       py         () const { return _py;         }
@@ -139,7 +137,6 @@ namespace larcv {
     inline void nu_interaction_type (short itype) {_interaction_type = itype; }
     // particle's info setter
     inline void track_id        (unsigned int id )   { _trackid = id;       }
-    inline void gen_id          (unsigned int id )   { _genid = id;       }
     inline void pdg_code        (int code)           { _pdg = code;         }
     inline void momentum        (double px, double py, double pz) { _px = px; _py = py; _pz = pz; }
     inline void end_momentum  (double end_px, double end_py, double end_pz) { _end_px = end_px; _end_py = end_py; _end_pz = end_pz; }
@@ -192,7 +189,6 @@ namespace larcv {
     short _interaction_type;   ///< if neutrino, shows interaction GENIE code. else kINVALID_USHORT
 
     unsigned int _trackid;     ///< Geant4 track id
-    unsigned int _genid;       ///< Original generator ID, if different from Geant4 one (e.g.: GENIE particle ID)
     int          _pdg;         ///< PDG code
     double       _px,_py,_pz;  ///< (x,y,z) component of particle's initial momentum
     double       _end_px,_end_py,_end_pz;  ///< (x,y,z) component of particle's final momentum


### PR DESCRIPTION
1. Remove `genid `which is no longer needed as the edepsim trajectory id is correctly propagated as `trackid ` now
2. Change `tpc` variable in flash to a more generic ` volume_id`